### PR TITLE
Moving the EyeInfo Dataset to `data` folder

### DIFF
--- a/.dvc/config
+++ b/.dvc/config
@@ -1,4 +1,5 @@
 [core]
     remote = remote
+    autostage = true
 ['remote "remote"']
     url = gdrive://1JMtJfAr1dWrjsbYjPaqV3-FvSskEO0AN

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,3 @@
-# DVC folders
-/01_dataset
-/02_eye_feature
-/03_metadata
-
 # Operating System folders
 .DS_Store
 

--- a/data/.gitignore
+++ b/data/.gitignore
@@ -1,0 +1,4 @@
+# DVC folders
+/01_dataset
+/02_eye_feature
+/03_metadata

--- a/data/01_dataset.dvc
+++ b/data/01_dataset.dvc
@@ -2,4 +2,5 @@ outs:
 - md5: 3ffd9ede826f65f0f1a2b2136aab3736.dir
   size: 70345818
   nfiles: 6011
+  hash: md5
   path: 01_dataset

--- a/data/02_eye_feature.dvc
+++ b/data/02_eye_feature.dvc
@@ -2,4 +2,5 @@ outs:
 - md5: 9f9c0bfeee8030b8bedc35652bf2e44c.dir
   size: 212244195
   nfiles: 166
+  hash: md5
   path: 02_eye_feature

--- a/data/03_metadata.dvc
+++ b/data/03_metadata.dvc
@@ -2,4 +2,5 @@ outs:
 - md5: 64729f9fd5d88eb1c1d8c292a6bd29bc.dir
   size: 1684368
   nfiles: 166
+  hash: md5
   path: 03_metadata


### PR DESCRIPTION
This commit organizes all files of the dataset in the data folder.